### PR TITLE
feat: dark-mode-in-country

### DIFF
--- a/country.css
+++ b/country.css
@@ -1,10 +1,50 @@
+/* Light mode styles */
+body {
+    background-color: #fff;
+    color: #000;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #2f2f2f;
+    color: #fff;
+}
+
+.dark-mode .title-container {
+    background-color: #333;
+}
+
+.dark-mode .country-details {
+    background-color: #444;
+    color: #fff;
+}
+
+.dark-mode .back-button {
+    background-color: #666;
+    color: #fff;
+}
+
+.dark-mode .border-countries a {
+    background-color: #555;
+    color: #fff;
+}
+
+/* Additional styles for the dark mode toggle button */
+.dark-mode-toggle {
+    background: none;
+    border: none;
+    color: #2f2f2f;
+    cursor: pointer;
+}
+
+.dark-mode .dark-mode-toggle {
+    color: #fff;
+}
 
 .countries-detail-container{
     min-width: 1200px;
     margin-inline: auto;
 }
-
-
 
 .back-button{
     box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.2);

--- a/country.html
+++ b/country.html
@@ -14,7 +14,11 @@
     <header class="title-container">
         <div class="title-content">
             <h2 class="title"><a href="/">Where in the world?</a></h2>
-            <p> <i class="fa-regular fa-moon"></i> &nbsp;Dark Mode</p>
+            <p>
+                <button id="dark-mode-toggle" class="dark-mode-toggle">
+                    <i class="fa-regular fa-moon"></i>&nbsp;Dark Mode
+                </button>
+            </p>
         </div>
     </header>
     <main>

--- a/country.js
+++ b/country.js
@@ -1,5 +1,4 @@
 const countryName = new URLSearchParams(window.location.search).get('name')
-//console.log(countryName);
 const flagImage = document.querySelector('.country-details img')
 const countryNameH1 = document.querySelector('.country-details h1')
 const nativeName = document.querySelector('.native-name')
@@ -15,43 +14,57 @@ const borderCountries = document.querySelector('.border-countries')
 fetch(`https://restcountries.com/v3.1/name/${countryName}?fullText=true`)
 .then((res)=>res.json())
 .then(([country])=>{
-//console.log(country.borders)
-flagImage.src = country.flags.svg
-countryNameH1.innerText = country.name.common
+    flagImage.src = country.flags.svg
+    countryNameH1.innerText = country.name.common
 
-if(country.name.nativeName)
-nativeName.innerText = Object.values(country.name.nativeName)[0].common
-else nativeName.innerText = country.name.common
+    if(country.name.nativeName)
+        nativeName.innerText = Object.values(country.name.nativeName)[0].common
+    else nativeName.innerText = country.name.common
 
-population.innerText = country.population.toLocaleString('en-IN')
-region.innerText = country.region
-subRegion.innerText = country.subregion
-capital.innerText = country.capital
-ToplevelDomain.innerText = country.tld.join(', ')
+    population.innerText = country.population.toLocaleString('en-IN')
+    region.innerText = country.region
+    subRegion.innerText = country.subregion
+    capital.innerText = country.capital
+    ToplevelDomain.innerText = country.tld.join(', ')
 
-if(country.currencies)
-Currencies.innerText = Object.values(country.currencies)[0].name
+    if(country.currencies)
+        Currencies.innerText = Object.values(country.currencies)[0].name
+    else Currencies.innerText = 'NA'
 
-else Currencies.innerText = 'NA'
+    Languages.innerText = Object.values(country.languages)[0]
 
-Languages.innerText = Object.values(country.languages)[0]
+    if(country.borders){
+        country.borders.forEach((border) => {
+            fetch(`https://restcountries.com/v3.1/alpha/${border}`)
+            .then((res)=>res.json())
+            .then(([borderCountry])=>{
+                const borderCountryTag = document.createElement('a')
+                borderCountryTag.innerText = borderCountry.name.common
+                borderCountryTag.href = `country.html?name=${borderCountry.name.common}`
+                borderCountries.append(borderCountryTag)
+            })
+        })
+    }
+})
 
-if(country.borders){
+// Toggle Dark Mode
+const darkModeToggle = document.getElementById('dark-mode-toggle');
 
-    country.borders.forEach((border) => {
-        //console.log(border);
-        fetch(`https://restcountries.com/v3.1/alpha/${border}`)
-        .then((res)=>res.json())
-        .then(([borderCountry])=>{
-            //console.log(borderCountry)
-            const borderCountryTag = document.createElement('a')
-            borderCountryTag.innerText = borderCountry.name.common
-            borderCountryTag.href = `country.html?name=${borderCountry.name.common}`
-            //console.log(borderCountryTag);
-            borderCountries.append(borderCountryTag)
-
-    })
-    })
+// Check if Dark Mode preference is saved
+const currentTheme = localStorage.getItem('theme');
+if (currentTheme === 'dark') {
+    document.body.classList.add('dark-mode');
+} else {
+    document.body.classList.remove('dark-mode');
 }
-}
-)
+
+// Add event listener to toggle dark mode
+darkModeToggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    // Save the theme preference
+    if (document.body.classList.contains('dark-mode')) {
+        localStorage.setItem('theme', 'dark');
+    } else {
+        localStorage.setItem('theme', 'light');
+    }
+});


### PR DESCRIPTION

Feature: Dark Mode Toggle
Description: This PR introduces a dark mode toggle functionality to the website, which allows users to switch between dark and light themes. The dark mode button's default text is black, which changes color according to the theme.

fixes #1 

Changes Included in this PR:
Added a dark mode toggle button to the header section.
Implemented JavaScript to toggle between light and dark themes.
Updated CSS styles for dark mode (background, text colors, etc.).
Added localStorage to remember the theme preference across sessions.
Made changes to the HTML and CSS files to integrate dark mode styling.
How to Test
Go to the  country page
Click the Dark Mode button in the header.
Verify that the theme switches between light and dark modes.
Refresh the page and ensure the theme preference is retained.
![l](https://github.com/user-attachments/assets/cc3f2c9c-e6d5-49e6-87c4-9dc386c63f7d)

